### PR TITLE
Remove json content-type header from POST

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ impl TestClient {
         RequestBuilder {
             builder: self.client.post(format!("http://{}{}", self.addr, url)),
         }
-        .header("Content-Type", "application/json")
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
The preset content-type header made it impossible to test endpoints that require different headers like multipart/form-data for example. Additionally if the body is created via the json method the content-type gets set to application/json by reqwest automatically either way.