### PR TITLE
disable trace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ hyper = "0.14.23"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+
+[features]
+default = [ "withtrace" ]
+withtrace = []
+withouttrace = []

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ the [example directory][examples].
 
 See the [crate documentation][docs] for way more examples.
 
+## Disable trace
+
+By default axum-test-helper print trace like `Listening on 127.0.0.1:36457`. You can disable trace with `axum-test-helper = { version = "0.*", default-features = false, features = ["withouttrace"] }`.
+
 ## License
 
 This project is licensed under the [MIT license][license].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ impl TestClient {
     {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Could not bind ephemeral socket");
         let addr = listener.local_addr().unwrap();
+        #[cfg(feature = "withouttrace")]
+        print!("");
+        #[cfg(feature = "withtrace")]
         println!("Listening on {}", addr);
 
         tokio::spawn(async move {


### PR DESCRIPTION
By default axum-test-helper print trace like `Listening on 127.0.0.1:36457`. You can disable trace with `axum-test-helper = { version = "0.*", default-features = false, features = ["withouttrace"] }`.