### PR TITLE
add ability to post form data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,10 @@ tokio = "1"
 hyper = "0.14.23"
 
 [dev-dependencies]
+serde = { version = "1", features = ["serde_derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [features]
-default = [ "withtrace" ]
+default = ["withtrace"]
 withtrace = []
 withouttrace = []


### PR DESCRIPTION
Axum has the ability to extract form data which is mentioned here: https://docs.rs/axum/0.6.18/axum/struct.Form.html

When trying to write tests for my code I found that there was no clear way to submit a form data request, so I added it in. This is already exposed in reqwest and can be seen here: https://docs.rs/reqwest/0.11.18/reqwest/index.html#forms