### PR TITLE
Add basic cookie support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ tokio = { version = "1", features = ["full"] }
 
 [features]
 default = ["withtrace"]
+cookies = ["reqwest/cookies"]
 withtrace = []
 withouttrace = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,14 @@ impl TestClient {
             server.await.expect("server error");
         });
 
+        #[cfg(feature = "cookies")]
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .cookie_store(true)
+            .build()
+            .unwrap();
+
+        #[cfg(not(feature = "cookies"))]
         let client = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .build()


### PR DESCRIPTION
This adds very basic cookie support, less to allow any kind of asserts on cookies and more to just allow tests to use the common login, then test call that requires login workflow required for login session cookie based authentication.

This should be roughly what I requested in #18