### PR TITLE
Expose base URL to allow for easier validation of Location headers in responses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,14 @@ impl TestClient {
         TestClient { client, addr }
     }
 
+    /// returns the base URL (http://ip:port) for this TestClient
+    ///
+    /// this is useful when trying to check if Location headers in responses
+    /// are generated correctly as Location contains an absolute URL
+    pub fn base_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
     pub fn get(&self, url: &str) -> RequestBuilder {
         RequestBuilder {
             builder: self.client.get(format!("http://{}{}", self.addr, url)),


### PR DESCRIPTION
The Location header in HTTP responses contains an absolute URL.

By exposing the listen IP and random port the way it is used internally to call the code being tested we can do a simple

assert_eq!(response_location_header, format!("{}/path/we/want", test_client.base_url()));

instead of having to parse the URL to throw that bit away before asserting on the rest of the URL somehow.