### PR TITLE
Address Hyper v1 Compatibility with Breaking Changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ serde_json = "1.0"
 
 [features]
 default = ["withtrace"]
-cookies = []
+cookies = ["reqwest/cookies"]
 withtrace = []
 withouttrace = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ readme = "README.md"
 repository = "https://github.com/cloudwalk/axum-test-helper"
 
 [dependencies]
-axum = "0.6"
-reqwest = { version = "0.11", features = ["json", "stream", "multipart", "rustls-tls"], default-features = false }
-http = "0.2"
+axum = "0.7"
 http-body = "0.4"
 bytes = "1.4.0"
 tower = "0.4.13"
 tower-service = "0.3"
 serde = "1.0"
 tokio = "1"
-hyper = "0.14"
+hyper = "1"
+http = "1.0.0"
+reqwest = { version = "0.11.23", features = ["json", "multipart"] }
 
 [dev-dependencies]
 serde = { version = "1", features = ["serde_derive"] }
@@ -29,6 +29,6 @@ serde_json = "1.0"
 
 [features]
 default = ["withtrace"]
-cookies = ["reqwest/cookies"]
+cookies = []
 withtrace = []
 withouttrace = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/cloudwalk/axum-test-helper"
 
 [dependencies]
 axum = "0.7"
+reqwest = { version = "0.11.23", features = ["json", "stream", "multipart", "rustls-tls"], default-features = false }
+http = "1.0.0"
 http-body = "0.4"
 bytes = "1.4.0"
 tower = "0.4.13"
@@ -19,8 +21,6 @@ tower-service = "0.3"
 serde = "1.0"
 tokio = "1"
 hyper = "1"
-http = "1.0.0"
-reqwest = { version = "0.11.23", features = ["json", "multipart"] }
 
 [dev-dependencies]
 serde = { version = "1", features = ["serde_derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,9 @@ impl TestResponse {
         StatusCode::from_u16(self.response.status().as_u16()).unwrap()
     }
 
-    // pub fn headers(&self) -> &http::HeaderMap {
-    //     self.response.headers()
-    // }
+    pub fn headers(&self) -> &reqwest::header::HeaderMap {
+        self.response.headers()
+    }
 
     pub async fn chunk(&mut self) -> Option<Bytes> {
         self.response.chunk().await.unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,12 +218,7 @@ impl AsRef<reqwest::Response> for TestResponse {
 #[cfg(test)]
 mod tests {
     use axum::response::Html;
-    use axum::{
-        response::{IntoResponse, Response},
-        routing::get,
-        routing::post,
-        Json, Router,
-    };
+    use axum::{routing::get, routing::post, Json, Router};
     use http::StatusCode;
     use serde::{Deserialize, Serialize};
 
@@ -232,8 +227,8 @@ mod tests {
         val: String,
     }
 
-    async fn handle_form(axum::Form(form): axum::Form<FooForm>) -> Response {
-        (StatusCode::OK, Html(form.val)).into_response()
+    async fn handle_form(axum::Form(form): axum::Form<FooForm>) -> (StatusCode, Html<String>) {
+        (StatusCode::OK, Html(form.val))
     }
 
     #[tokio::test]


### PR DESCRIPTION
Hi! 

Thank you for your work on this crate. This is exactly what I wanted to test API endpoints to prevent auth errors.

Our current app is using Hyper v1 so I had to modify this crate quite a bit to get it to work. Here I introduce a few breaking changes which may not be what you are looking for (especially removing the ability to test `tower::Service`s not just `axum::Router`s).

If this is not helpful or too drastic feel free to close this PR.

Thank you!
Austin